### PR TITLE
Check if the full path exists locally. Not just the dependencies folder

### DIFF
--- a/bin/translate_dependency_url
+++ b/bin/translate_dependency_url
@@ -17,10 +17,10 @@ if translated_uri.nil?
   exit 1
 end
 
-if File.exist? cache_path
-  file_path = File.join(cache_path, translated_uri.gsub(/[\/:]/, '_'))
+cached_file_path = File.join(cache_path, translated_uri.gsub(/[\/:]/, '_'))
+if File.exist? cached_file_path
 
-  puts "file://#{file_path}"
+  puts "file://#{cached_file_path}"
 else
   puts translated_uri
 end


### PR DESCRIPTION
This change allows you to have only some of the manifest.yml dependencies available locally. Without this change, all dependencies are expected to be in the dependencies folder, if the dependencies folder exists. 
