### PR TITLE
Optional environment variable to ignore stack check

### DIFF
--- a/bin/check_stack_support
+++ b/bin/check_stack_support
@@ -3,6 +3,9 @@
 require 'yaml'
 manifest_path = File.join(File.dirname(__FILE__), '..', '..', 'manifest.yml')
 manifest = YAML.load_file(manifest_path)
+
+exit 0 if ENV['SKIP_CF_STACK_CHECK'] == "true"
+
 dependency = manifest['dependencies'].find do |dependency|
   dependency['cf_stacks'].include?(ENV['CF_STACK'])
 end

--- a/lib/dependencies.rb
+++ b/lib/dependencies.rb
@@ -80,7 +80,7 @@ module CompileExtensions
     end
 
     def dependency_satisfies_current_stack(dependency)
-      dependency['cf_stacks'].include?(stack)
+      ENV['SKIP_CF_STACK_CHECK'] == "true" || dependency['cf_stacks'].include?(stack)
     end
 
     def stack


### PR DESCRIPTION
Use Case for this PR: We want to rename our stacks based on different environment and to keep on using the upstream buildpacks this option can be helpful which can be turned on from application manifest itself and if it is not defined then buildpack will show default behavior of verifying stack .

```

---
applications:
- name: stacktest
   env:
        SKIP_CF_STACK_CHECK: true
```
