### PR TITLE
`download_dependency` can follow HTTP redirects

### DIFF
--- a/bin/download_dependency
+++ b/bin/download_dependency
@@ -26,7 +26,7 @@ if File.exist? cache_path
   translated_uri = "file://#{file_path}"
 end
 
-`curl -s #{translated_uri} -o #{file_location}`
+`curl -s -L #{translated_uri} -o #{file_location}`
 generated_md5 = Digest::MD5.file(file_location).hexdigest
 
 puts translated_uri


### PR DESCRIPTION
This change allows the `curl` inside `download_dependency` to follow the `Location:` header of any HTTP 3xx response it receives.
