### PR TITLE
Only check deps within the same stack

### DIFF
--- a/bin/default_version_for
+++ b/bin/default_version_for
@@ -29,7 +29,7 @@ class DefaultVersionIdentifier
   def run
     dependency_defaults = default_dependency_versions.select { |default_dependency_versions_entry| default_dependency_versions_entry['name'] == requested_dependency_name }
 		if dependency_defaults.empty?
-			dependency_defaults = @dependencies.select { |d| d['name'] == requested_dependency_name && d['cf_stacks'].include?(ENV['CF_STACK']) }
+			dependency_defaults = @dependencies.select { |d| d['name'] == requested_dependency_name && (d['cf_stacks'].nil? || d['cf_stacks'].include?(ENV['CF_STACK'])) }
 		end
 		verify_single_default_dependency_version_provided(dependency_defaults)
 

--- a/bin/default_version_for
+++ b/bin/default_version_for
@@ -29,7 +29,7 @@ class DefaultVersionIdentifier
   def run
     dependency_defaults = default_dependency_versions.select { |default_dependency_versions_entry| default_dependency_versions_entry['name'] == requested_dependency_name }
 		if dependency_defaults.empty?
-			dependency_defaults = @dependencies.select { |d| d['name'] == requested_dependency_name }
+			dependency_defaults = @dependencies.select { |d| d['name'] == requested_dependency_name && d['cf_stacks'].include?(ENV['CF_STACK']) }
 		end
 		verify_single_default_dependency_version_provided(dependency_defaults)
 


### PR DESCRIPTION
and allow defining the stack with the environment variable `CF_STACK`.

We have to maintain a fork of `compile-extensions` for this small change so it would be great if you could merge it.

Thanks in advance.